### PR TITLE
(Bugfix) Fixes #1, Unescape characters

### DIFF
--- a/tasks/template.html
+++ b/tasks/template.html
@@ -1,7 +1,7 @@
 <dom-module id="{{id}}">
     <template>
         <style>
-{{css}}
+{{{css}}}
         </style>
     </template>
 </dom-module>


### PR DESCRIPTION
Mustache was escaping the characters in the CSS file.
